### PR TITLE
AeInputAmount, AccountsNew: Disable autocompletion

### DIFF
--- a/src/components/AeInputAmount.vue
+++ b/src/components/AeInputAmount.vue
@@ -8,6 +8,7 @@
       v-focus.lazy="autofocus"
       slot-scope="{ setFocus, id }"
       placeholder="0.0"
+      autocomplete="off"
       :value="value"
       v-bind="$attrs"
       type="number"

--- a/src/pages/mobile/AccountsNew.vue
+++ b/src/pages/mobile/AccountsNew.vue
@@ -18,6 +18,7 @@
           v-model="newAccountName"
           v-validate="'required'"
           autofocus
+          autocomplete="off"
           :error="errors.has('newAccountName')"
           :footer="errors.first('newAccountName')"
           name="newAccountName"


### PR DESCRIPTION
This PR disables autocompletion that looks like this:

| AccountsNew screen | SendAmount screen | 
| ---------------------------- | --------------------------- |
| ![screenshot from 2019-02-11 19-16-50](https://user-images.githubusercontent.com/9007851/52684015-08e53a00-2f45-11e9-83b0-c44a39e8686b.png) | ![screenshot from 2019-02-11 19-17-03](https://user-images.githubusercontent.com/9007851/52684016-097dd080-2f45-11e9-85d3-bb6b5d5a2197.png) |

This feature doesn't look useful for the end user and also it a bit annoying while development.