### PR TITLE
Cordova iOS: Fix wraping iframe if it width greater than viewport

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ if (process.env.NODE_ENV === 'development') {
 Vue.config.productionTip = false;
 Vue.prototype.$globals = {
   IS_MOBILE_DEVICE: process.env.IS_MOBILE_DEVICE,
+  IS_IOS: process.env.IS_IOS,
 };
 
 new Vue({

--- a/src/pages/mobile/AppBrowser.vue
+++ b/src/pages/mobile/AppBrowser.vue
@@ -36,6 +36,7 @@
     <iframe
       ref="iframe"
       :src="url"
+      :scrolling="$globals.IS_IOS && 'no'"
       @load="loading = false"
     />
   </div>
@@ -130,6 +131,7 @@ export default {
 
   iframe {
     flex-grow: 1;
+    width: 100vw;
     border: none;
   }
 }


### PR DESCRIPTION
Fixes #480 
https://stackoverflow.com/questions/23083462/how-to-get-an-iframe-to-be-responsive-in-ios-safari
https://www.spacevatican.org/2015/4/7/on-mobile-safari-and-iframes/