### PR TITLE
Cordova iOS: Fix visited link border color

### DIFF
--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -61,10 +61,6 @@ export default {
     background-color: $color-neutral-positive-3;
   }
 
-  &:visited .content {
-    border: inherit;
-  }
-
   .content {
     display: flex;
     align-items: center;
@@ -99,11 +95,15 @@ export default {
     }
   }
 
-  & + .list-item .content {
-    border-top: 2px solid $color-neutral-positive-2;
+  & + .list-item {
+    &, &:visited {
+      .content {
+        border-top: 2px solid $color-neutral-positive-2;
 
-    &.border-dark {
-      border-top-color: $color-neutral-positive-1;
+        &.border-dark {
+          border-top-color: $color-neutral-positive-1;
+        }
+      }
     }
   }
 

--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -61,6 +61,10 @@ export default {
     background-color: $color-neutral-positive-3;
   }
 
+  &:visited .content {
+    border: inherit;
+  }
+
   .content {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Fixes #479 
Looks like that's how browsers work with visited links: https://markmail.org/message/x3iwbm4gqpuagzq3
Solution proposed in https://stackoverflow.com/questions/13427606/mobile-safari-odd-border-color-issue