### PR TITLE
Don't require PWA in development

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,7 +8,7 @@ import AddToHomeScreenPrompt from '../pages/mobile/AddToHomeScreenPrompt.vue';
 const router = new Router({
   routes:
     process.env.IS_MOBILE_DEVICE
-      ? (!process.env.IS_CORDOVA && !process.env.IS_PWA && !process.env.IS_IOS
+      ? (!process.env.IS_CORDOVA && !process.env.IS_PWA && !process.env.IS_IOS && process.env.NODE_ENV === 'production'
         && [{
           path: '/',
           component: AddToHomeScreenPrompt,


### PR DESCRIPTION
After merging of #481 becomes more difficult to work with Base app in developing (aepp browser is not scrollable anymore in emulation of mobile Safari). I propose to hide well-known AddToHomeScreenPrompt screen (that requires to switch to PWA in Android) in development mode to make possible work with Base app in emulation of non-iOS mobile devices.