### PR TITLE
TabBar: Make it static on small screens

### DIFF
--- a/src/components/mobile/TabBar.vue
+++ b/src/components/mobile/TabBar.vue
@@ -59,6 +59,10 @@ export default {
   bottom: 0;
   background-color: $color-neutral-minimum;
 
+  @media (max-height: 500px) {
+    position: static;
+  }
+
   .wrapper {
     display: flex;
     align-items: center;


### PR DESCRIPTION
closes #499 

Also, I tried to really hide TabBar listening to `focus`/`blur` events, but TabBar was appearing earlier than keyboard hides making impossible to click on a submit button if it right above the keyboard. Fixing it by binding to `resize` event makes it too fragile.

One more option is to detect keyboard appearance by the difference between `orientationchange` window event and changing of `(orientation: portrait)` media query, but it doesn't work in landscape mode.

ps Looks like `rem()` can't be used in media queries.