### PR TITLE
mobile Header: Use proper slot name

### DIFF
--- a/src/components/mobile/Header.vue
+++ b/src/components/mobile/Header.vue
@@ -60,7 +60,7 @@ export default {
   computed: {
     empty() {
       return !(this.title
-        || this.$slots.title
+        || this.$slots.default
         || this.leftButtonIconName
         || this.rightButtonIconName);
     },


### PR DESCRIPTION
It should fix this behavior:
![photo_2019-04-12_12-36-17](https://user-images.githubusercontent.com/9007851/56031389-a4b1dd00-5d1f-11e9-9137-4b9c9660fdc9.jpg)
