### PR TITLE
router: Enable HTML5 history mode

### DIFF
--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -6,7 +6,7 @@ if [[ $TRAVIS_OS_NAME != "osx" ]]; then
   npm run test:unit
   npm run build -- --report
 
-  npx serve dist &
+  npx serve --single dist &
   trap "kill $!" EXIT
   npm run test:e2e -- --headless --url http://localhost:5000
 fi

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,7 @@ import commonRoutes from './routes/common';
 import AddToHomeScreenPrompt from '../pages/mobile/AddToHomeScreenPrompt.vue';
 
 const router = new Router({
+  mode: process.env.IS_CORDOVA ? 'hash' : 'history',
   routes:
     process.env.IS_MOBILE_DEVICE
       ? (!process.env.IS_CORDOVA && !process.env.IS_PWA && !process.env.IS_IOS && process.env.NODE_ENV === 'production'

--- a/tests/e2e/specs/migrations/00-fix-aes-ctr-counter-issue.js
+++ b/tests/e2e/specs/migrations/00-fix-aes-ctr-counter-issue.js
@@ -47,7 +47,7 @@ describe('Migration 0: Fix AES-CTR counter issue', () => {
     });
     cy
       .viewport('iphone-5')
-      .visit('/#/login')
+      .visit('/login')
       .get('input[type=password]').type('1234')
       .get('button')
       .contains('Log in')

--- a/tests/e2e/specs/migrations/02-build-accounts-array.js
+++ b/tests/e2e/specs/migrations/02-build-accounts-array.js
@@ -69,7 +69,7 @@ describe('Migration 2: Build accounts array', () => {
     window.localStorage.vuex = JSON.stringify(stateBeforeMigration);
     cy
       .viewport('iphone-5')
-      .visit('/#/login')
+      .visit('/login')
       .get('input[type=password]').type('1234')
       .get('button')
       .contains('Log in')


### PR DESCRIPTION
Let's drop `#` out of Base app URLs, for example:
`https://base.aepps.com/#/transfer` make just `https://base.aepps.com/transfer`

Though it will break all existing links and it requires additional configuration of development and production servers.

more info here: https://router.vuejs.org/guide/essentials/history-mode.html