### PR TITLE
 Fix splash screen by enabling SplashMaintainAspectRatio

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -15,6 +15,7 @@
     <allow-navigation href="*" />
     <platform name="android">
         <allow-intent href="market:*" />
+        <preference name="SplashMaintainAspectRatio" value="true" />
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />

--- a/config.xml
+++ b/config.xml
@@ -20,12 +20,12 @@
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <preference name="UseSwiftLanguageVersion" value="5" />
+        <preference name="DisallowOverscroll" value="true" />
     </platform>
     <preference name="SplashScreen" value="screen" />
     <feature name="SplashScreen">
         <param name="onload" value="true" />
     </feature>
-    <preference name="DisallowOverscroll" value="true" />
     <plugin name="cordova-plugin-whitelist" spec="^1.3.3" />
     <plugin name="cordova-plugin-splashscreen" spec="^5.0.2" />
     <plugin name="cordova-plugin-customurlscheme" spec="^4.3.0">


### PR DESCRIPTION
https://stackoverflow.com/questions/23157049/cordova-android-splashscreen-are-distorted
https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/#preferences

| Before | After |
|--------|------|
| ![photo_2019-04-23_10-04-49](https://user-images.githubusercontent.com/9007851/56564839-3f77aa80-65af-11e9-8187-cd17ed6c03a1.jpg) | ![photo_2019-04-23_10-04-59](https://user-images.githubusercontent.com/9007851/56564845-430b3180-65af-11e9-9bec-04551aee18a8.jpg) |


