### PR TITLE
initSdk: Avoid account address confirmation in reverse iframe mode

### DIFF
--- a/src/store/plugins/initSdk.js
+++ b/src/store/plugins/initSdk.js
@@ -18,7 +18,7 @@ export default (store) => {
 
       const methods = {
         async address(options) {
-          if (options) {
+          if (options && !process.env.RUNNING_IN_FRAME) {
             const { app } = options;
             const accessToAccounts = get(app, 'permissions.accessToAccounts', []);
             if (!accessToAccounts.includes(store.getters.activeAccount.address)) {


### PR DESCRIPTION
It should fix exception in Firefox:
> Unhandled rejection TypeError: promise is undefined
    _callee$/<@webpack-internal:///./src/store/plugins/initSdk.js:111:31
    Promise@webpack-internal:///./node_modules/@babel/runtime-corejs2/node_modules/core-js/library/modules/es6.promise.js:177:7
    _callee$@webpack-internal:///./src/store/plugins/initSdk.js:110:183
    tryCatch@webpack-internal:///./node_modules/regenerator-runtime/runtime.js:62:37
    invoke@webpack-internal:///./node_modules/regenerator-runtime/runtime.js:288:22
    defineIteratorMethods/</prototype[method]@webpack-internal:///./node_modules/regenerator-runtime/runtime.js:114:16
From previous event:
    address@webpack-internal:///./src/store/plugins/initSdk.js:78:26
    init/this.rpcMethods</<@webpack-internal:///./src/store/plugins/initSdk.js:399:30
    call@webpack-internal:///./node_modules/ramda/es/call.js:38:10
    f1@webpack-internal:///./node_modules/ramda/es/internal/_curry1.js:19:14
    _callee$@webpack-internal:///./node_modules/@aeternity/aepp-sdk/es/rpc/server.js:88:13
    tryCatch@webpack-internal:///./node_modules/regenerator-runtime/runtime.js:62:37
    invoke@webpack-internal:///./node_modules/regenerator-runtime/runtime.js:288:22
    defineIteratorMethods/</prototype[method]@webpack-internal:///./node_modules/regenerator-runtime/runtime.js:114:16
From previous event:
    receive@webpack-internal:///./node_modules/@aeternity/aepp-sdk/es/rpc/server.js:61:10