### PR TITLE
modals plugin: Hide modals under modal with 'hidePage'

### DIFF
--- a/src/store/plugins/modals.js
+++ b/src/store/plugins/modals.js
@@ -27,11 +27,9 @@ export default (store) => {
       },
     },
     getters: {
-      opened: ({ opened }) => opened.map(({ name, key, props }) => ({
-        ...modals[name],
-        key,
-        props,
-      })),
+      opened: ({ opened }) => opened
+        .map(({ name, ...other }) => ({ ...modals[name], ...other }))
+        .reduceRight((acc, modal) => (acc.length && acc[0].hidePage ? acc : [modal, ...acc]), []),
     },
     actions: Object.keys(modals).reduce((p, name) => ({
       ...p,


### PR DESCRIPTION
Fixes bugs like:
<table>
<tr>
<td> Request signing of two transactions by remote connection</td>
<td> Request signing of a transaction by remote connection when account switcher is opened </td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/9007851/57006685-f7760a80-6be2-11e9-82ec-1f58598c64ed.png" /></td>
<td><img src="https://user-images.githubusercontent.com/9007851/57006662-be3d9a80-6be2-11e9-929d-23844a848c67.png" /></td>
</tr>
</table>