### PR TITLE
Fix error message typo for closing some modals

### DIFF
--- a/src/components/desktop/LedgerTransactionFeeModal.vue
+++ b/src/components/desktop/LedgerTransactionFeeModal.vue
@@ -86,7 +86,7 @@ export default {
       this.resolve(BigNumber(this.fee).shiftedBy(MAGNITUDE_MICRO));
     },
     handleClose() {
-      this.reject(new Error('Canceled by user'));
+      this.reject(new Error('Cancelled by user'));
     },
   },
 };

--- a/src/components/mobile/VaultSignModal.vue
+++ b/src/components/mobile/VaultSignModal.vue
@@ -56,7 +56,7 @@ export default {
   }),
   methods: {
     closeHandler() {
-      this.reject(new Error('Canceled by user'));
+      this.reject(new Error('Cancelled by user'));
     },
   },
 };


### PR DESCRIPTION
For example, https://github.com/aeternity/aepp-base/blob/15f0fc3212b676cdf2bc33edbb2db4cb30b8f8d5/src/pages/mobile/SendConfirm.vue#L41 is waiting for right `Cancelled by user` but receiving `Canceled by user`