### PR TITLE
Fix calling of sync method of SDK by dapp

### DIFF
--- a/src/store/plugins/initSdk.js
+++ b/src/store/plugins/initSdk.js
@@ -68,7 +68,7 @@ export default (store) => {
                   .map(m => [m, ({ params, origin }) => {
                     const { host } = new URL(origin);
                     const app = store.getters.getApp(host) || { host };
-                    return this[m](...params, { app });
+                    return Promise.resolve(this[m](...params, { app }));
                   }])
                   .reduce((p, [k, v]) => ({ ...p, [k]: v }), {}),
                 ...this.rpcMethods,


### PR DESCRIPTION
Fixes exception:
> Unhandled rejection TypeError: ramda__WEBPACK_IMPORTED_MODULE_9__.call(...).then is not a function
at Object._callee$ (webpack-internal:///./node_modules/@aeternity/aepp-sdk/es/rpc/server.js:92:16)
at tryCatch (webpack-internal:///./node_modules/regenerator-runtime/runtime.js:62:40)
at Generator.invoke [as _invoke] (webpack-internal:///./node_modules/regenerator-runtime/runtime.js:288:22)
at Generator.prototype.(anonymous function) [as next] (webpack-internal:///./node_modules/regenerator-runtime/runtime.js:114:21)From previous event:
at Object.receive (webpack-internal:///./node_modules/@aeternity/aepp-sdk/es/rpc/server.js:61:19)

This change is necessary because `rpc/server.js` from SDK treads value returned from `rpcMethods` handler as a promise: https://github.com/aeternity/aepp-sdk-js/blob/03e475a9d254ee6370e7515723894a07f32ac42d/es/rpc/server.js#L44
closes #741 