### PR TITLE
Enable http in Android 8, 9

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -16,6 +16,9 @@
     <platform name="android">
         <allow-intent href="market:*" />
         <preference name="SplashMaintainAspectRatio" value="true" />
+        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
+          <application android:usesCleartextTraffic="true" />
+        </edit-config>
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />


### PR DESCRIPTION
closes #754
based on:
https://stackoverflow.com/questions/54752716/why-am-i-seeing-neterr-cleartext-not-permitted-errors-after-upgrading-to-cordo
https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted