### PR TITLE
syncState: Merge items of old array into items of new one

### DIFF
--- a/src/store/modules/root.js
+++ b/src/store/modules/root.js
@@ -74,14 +74,14 @@ export default {
 
   mutations: {
     syncState(state, remoteState) {
-      Object.entries(
-        mergeWith(
-          {},
-          state,
-          remoteState,
-          (objValue, srcValue) => (Array.isArray(srcValue) ? srcValue : undefined),
-        ),
-      )
+      const customizer = (objValue, srcValue) => {
+        if (!Array.isArray(srcValue)) return undefined;
+        if (!Array.isArray(objValue)) return srcValue;
+        return srcValue.map((el, idx) => (
+          el && typeof el === 'object' ? mergeWith({}, objValue[idx], el, customizer) : el
+        ));
+      };
+      Object.entries(mergeWith({}, state, remoteState, customizer))
         .forEach(([name, value]) => Vue.set(state, name, value));
     },
     markMigrationAsApplied(state, migrationId) {


### PR DESCRIPTION
Although it still has issues in merging of something like:
```
object 1: { t: [{ name: 'Item 1', secretKey: '...' }, { name: 'Item 2' }] }
object 2: { t: [{ name: 'Item 2' }] }
```
will result in
```
[{ name: 'Item 2', secretKey: '...' }]
```
to solve this we have to add some `key` system like Vue has, or sync mutations instead of state.

But as I see we don't have such cases for now.