### PR TITLE
initSdk: Fix case when networks switched faster than SDK inits

### DIFF
--- a/src/store/plugins/initSdk.js
+++ b/src/store/plugins/initSdk.js
@@ -5,86 +5,91 @@ import {
 import Rpc from '@aeternity/aepp-sdk/es/rpc/server';
 
 export default (store) => {
+  const updateSdk = async (url) => {
+    const methods = {
+      async address(options) {
+        if (options) {
+          const { app } = options;
+          const accessToAccounts = get(app, 'permissions.accessToAccounts', []);
+          if (!accessToAccounts.includes(store.getters['accounts/active'].address)) {
+            const promise = store.dispatch(
+              'modals/open',
+              { name: 'confirmAccountAccess', appHost: app.host },
+            );
+            const unsubscribe = store.watch(
+              (state, getters) => getters['accounts/active'].address,
+              address => accessToAccounts.includes(address) && promise.cancel(),
+            );
+
+            try {
+              await Promise.race([
+                promise,
+                new Promise((resolve, reject) => promise.finally(() => {
+                  if (!promise.isCancelled()) return;
+                  if (accessToAccounts.includes(store.getters['accounts/active'].address)) {
+                    resolve();
+                  } else reject(new Error('Unexpected state'));
+                })),
+              ]);
+            } finally {
+              unsubscribe();
+            }
+
+            const { address: accountAddress } = store.getters['accounts/active'];
+            if (!accessToAccounts.includes(accountAddress)) {
+              store.commit('toggleAccessToAccount', { appHost: app.host, accountAddress });
+            }
+          }
+        }
+        return store.getters['accounts/active'].address;
+      },
+      sign: data => store.dispatch('accounts/sign', data),
+      signTransaction: txBase64 => store.dispatch('accounts/signTransaction', txBase64),
+    };
+
+    let sdk = null;
+    try {
+      sdk = await Ae.compose(
+        ChainNode, Transaction, Contract, Rpc, {
+          init(options, { stamp }) {
+            const rpcMethods = [
+              ...stamp.compose.deepConfiguration.Ae.methods,
+              ...stamp.compose.deepConfiguration.Contract.methods,
+            ];
+            this.rpcMethods = {
+              ...rpcMethods
+                .map(m => [m, ({ params, origin }) => {
+                  const { host } = new URL(origin);
+                  const app = store.getters.getApp(host) || { host };
+                  return Promise.resolve(this[m](...params, { app }));
+                }])
+                .reduce((p, [k, v]) => ({ ...p, [k]: v }), {}),
+              ...this.rpcMethods,
+            };
+          },
+          methods,
+        },
+      )({
+        url,
+        internalUrl: url,
+        compilerUrl: 'https://compiler.aepps.com',
+      });
+    } finally {
+      if (store.state.sdk) store.state.sdk.destroyInstance();
+      store.commit('setSdk', sdk);
+    }
+  };
+
   let lastNetwork;
+  let updateSdkPromise;
 
   store.watch(
     ({ onLine }, { currentNetwork }) => [currentNetwork, onLine],
-    async ([currentNetwork]) => {
+    ([currentNetwork]) => {
       if (isEqual(currentNetwork, lastNetwork) && store.state.sdk) return;
       lastNetwork = currentNetwork;
-
-      const methods = {
-        async address(options) {
-          if (options) {
-            const { app } = options;
-            const accessToAccounts = get(app, 'permissions.accessToAccounts', []);
-            if (!accessToAccounts.includes(store.getters['accounts/active'].address)) {
-              const promise = store.dispatch(
-                'modals/open',
-                { name: 'confirmAccountAccess', appHost: app.host },
-              );
-              const unsubscribe = store.watch(
-                (state, getters) => getters['accounts/active'].address,
-                address => accessToAccounts.includes(address) && promise.cancel(),
-              );
-
-              try {
-                await Promise.race([
-                  promise,
-                  new Promise((resolve, reject) => promise.finally(() => {
-                    if (!promise.isCancelled()) return;
-                    if (accessToAccounts.includes(store.getters['accounts/active'].address)) {
-                      resolve();
-                    } else reject(new Error('Unexpected state'));
-                  })),
-                ]);
-              } finally {
-                unsubscribe();
-              }
-
-              const { address: accountAddress } = store.getters['accounts/active'];
-              if (!accessToAccounts.includes(accountAddress)) {
-                store.commit('toggleAccessToAccount', { appHost: app.host, accountAddress });
-              }
-            }
-          }
-          return store.getters['accounts/active'].address;
-        },
-        sign: data => store.dispatch('accounts/sign', data),
-        signTransaction: txBase64 => store.dispatch('accounts/signTransaction', txBase64),
-      };
-
-      let sdk = null;
-      try {
-        sdk = await Ae.compose(
-          ChainNode, Transaction, Contract, Rpc, {
-            init(options, { stamp }) {
-              const rpcMethods = [
-                ...stamp.compose.deepConfiguration.Ae.methods,
-                ...stamp.compose.deepConfiguration.Contract.methods,
-              ];
-              this.rpcMethods = {
-                ...rpcMethods
-                  .map(m => [m, ({ params, origin }) => {
-                    const { host } = new URL(origin);
-                    const app = store.getters.getApp(host) || { host };
-                    return Promise.resolve(this[m](...params, { app }));
-                  }])
-                  .reduce((p, [k, v]) => ({ ...p, [k]: v }), {}),
-                ...this.rpcMethods,
-              };
-            },
-            methods,
-          },
-        )({
-          url: currentNetwork.url,
-          internalUrl: currentNetwork.url,
-          compilerUrl: 'https://compiler.aepps.com',
-        });
-      } finally {
-        if (store.state.sdk) store.state.sdk.destroyInstance();
-        store.commit('setSdk', sdk);
-      }
+      if (updateSdkPromise) updateSdkPromise.cancel();
+      updateSdkPromise = updateSdk(currentNetwork.url);
     },
     { immediate: true },
   );


### PR DESCRIPTION
Steps to reproduce the original issue:
- switch to some network (other than `sdk-testnet` or `sdk-edgenet`)
- execute in JS console:
```js
store.commit('setSdkUrl', 'https://sdk-testnet.aepps.com');
setTimeout(() => store.commit('setSdkUrl', 'https://sdk-edgenet.aepps.com'), 500)
```
- compare values of `store.state.sdkUrl` and `store.state.sdk.url`

### Before this
```
> store.state.sdk.url
"https://sdk-testnet.aepps.com/"
> store.state.sdkUrl
"https://sdk-edgenet.aepps.com"
```

### After this
```
> store.state.sdk.url
VM12427:1 Uncaught TypeError: Cannot read property 'url' of null
    at <anonymous>:1:17
(anonymous) @ VM12427:1
> store.state.sdkUrl
"https://sdk-edgenet.aepps.com"
```