### PR TITLE
transaction list: Don't swallow middleware errors

### DIFF
--- a/src/store/plugins/ui/observables.js
+++ b/src/store/plugins/ui/observables.js
@@ -112,10 +112,8 @@ export default (store) => {
     mdwUrl.searchParams.set('limit', limit.toString());
     mdwUrl.searchParams.set('page', page.toString());
     const txs = await Promise.all(
-      mapKeysDeep(
-        await fetchJson(mdwUrl).catch(() => []),
-        (value, key) => camelCase(key),
-      ).map(normalizeTransaction),
+      mapKeysDeep(await fetchJson(mdwUrl), (value, key) => camelCase(key))
+        .map(normalizeTransaction),
     );
     txs.forEach(registerTx);
     return txs;


### PR DESCRIPTION
Looks like it is not necessary, because, in comparison with Epoch nodes, middleware doesn't return 404 code if account if not found:
https://testnet.mdw.aepps.com/middleware/transactions/account/ak_9p5pesfQtbTjRJqjJBwL1DK15bUTCX7jjPvmokK9wxvTAyhgD
