### PR TITLE
AeInputAmountAe: Shorten 'transaction' to 'tx'

### DIFF
--- a/src/components/AeInputAmountAe.vue
+++ b/src/components/AeInputAmountAe.vue
@@ -3,7 +3,7 @@
     class="ae-input-amount-ae"
     header="Amount"
     header-right="AE"
-    :footer="footer || 'Minimum transaction fee'"
+    :footer="footer || 'Minimum tx fee'"
     :footer-right="footerRight || (footer ? '' : minSpendTxFee)"
     :value="value"
     v-bind="$attrs"


### PR DESCRIPTION
I'm proposing to use 'tx' instead of 'transaction' here. It is common used shortcut for transactions, heavily used in our code. Closes #873.