### PR TITLE
Improve analytics integration

### DIFF
--- a/src/setupAnalytics.js
+++ b/src/setupAnalytics.js
@@ -1,21 +1,51 @@
-import Vue from 'vue';
-import Matomo from 'vue-matomo';
+import Matomo from 'vue-matomo/src/matomo';
 import Countly from 'countly-sdk-web';
 import { defer } from 'lodash-es';
 import router from './router';
+import store from './store';
 
 export default () => {
-  Vue.use(Matomo, {
-    host: process.env.VUE_APP_MATOMO_URL,
-    siteId: process.env.VUE_APP_MATOMO_SITE_ID,
-    router,
-  });
+  const matomo = Matomo.getTracker(
+    `${process.env.VUE_APP_MATOMO_URL}/piwik.php`,
+    process.env.VUE_APP_MATOMO_SITE_ID,
+  );
+  matomo.setCustomDimension(1, process.env.IS_MOBILE_DEVICE);
+  matomo.setCustomDimension(2, process.env.IS_PWA);
+  matomo.setCustomDimension(3, process.env.IS_IOS);
+  matomo.setCustomDimension(4, process.env.npm_package_version);
+  matomo.setCustomDimension(5, process.env.IS_CORDOVA);
+  matomo.setCustomVariable(1, 'accounts-count', store.state.accounts.list.length);
+  matomo.trackPageView();
+  matomo.enableLinkTracking();
+  matomo.enableJSErrorTracking();
 
   Countly.init({
     url: process.env.VUE_APP_COUNTLY_URL,
     app_key: process.env.VUE_APP_COUNTLY_APP_KEY,
+    app_version: process.env.npm_package_version,
   });
-  Countly.q.push(['track_sessions']);
-  router.afterEach(() => defer(() => Countly.q
-    .push(['track_pageview', window.location.pathname + window.location.hash])));
+  Countly.add_event({ key: `is-mobile-device:${process.env.IS_MOBILE_DEVICE}` });
+  Countly.add_event({ key: `is-pwa:${process.env.IS_PWA}` });
+  Countly.add_event({ key: `is-ios:${process.env.IS_IOS}` });
+  Countly.add_event({ key: `is-cordova:${process.env.IS_CORDOVA}` });
+  Countly.add_event({
+    key: 'accounts-count',
+    sum: store.state.accounts.list.length,
+  });
+  Countly.track_sessions();
+  Countly.track_links();
+  Countly.track_errors();
+
+  router.afterEach(() => defer(() => {
+    const url = window.location.pathname + window.location.hash;
+    matomo.setCustomUrl(url);
+    matomo.trackPageView();
+    Countly.track_pageview(url);
+  }));
+
+  store.subscribeAction(({ type, payload }) => {
+    if (type !== 'modals/open') return;
+    matomo.trackEvent('modal', 'open', payload.name);
+    Countly.add_event({ key: `modals/open/${payload.name}` });
+  });
 };

--- a/src/ui.js
+++ b/src/ui.js
@@ -9,14 +9,11 @@ import AppDesktop from './AppDesktop.vue';
 import router from './router';
 import store from './store';
 import uiPlugin from './store/plugins/ui';
-import setupAnalytics from './setupAnalytics';
 
 Vue.use(Router);
 Vue.use(VeeValidate);
 
-if (process.env.UNFINISHED_FEATURES) {
-  setupAnalytics();
-}
+import(/* webpackChunkName: "analytics" */ './setupAnalytics').then(module => module.default());
 
 sync(store, router);
 uiPlugin(store);


### PR DESCRIPTION
Based on:
- https://developer.matomo.org/api-reference/tracking-javascript
- https://developer.matomo.org/guides/tracking-javascript-guide
- https://resources.count.ly/docs/countly-sdk-for-web

Improvements:
- sends values of env variables to analytics
- sends a count of available accounts
- adds tracking of modals opening
- adds tracking of JS exceptions
- consistent setup of Matomo and Countly
- extracts analytics into the separate chunk

part of #841 

Need to ensure that tracked data is accessible through analytics frontends.