### PR TITLE
getAccountInfo: Don't return plain value in switchMap

### DIFF
--- a/src/store/plugins/ui/observables.js
+++ b/src/store/plugins/ui/observables.js
@@ -28,7 +28,7 @@ export default (store) => {
       switchMap(sdk => timer(0, 3000).pipe(map(() => sdk))),
       switchMap(sdk => (sdk
         ? sdk.api.getAccountByPubkey(address).catch(() => defaultAccountInfo)
-        : defaultAccountInfo)),
+        : Promise.resolve(defaultAccountInfo))),
       map(aci => ({ ...aci, balance: BigNumber(aci.balance).shiftedBy(-MAGNITUDE) })),
       multicast(new BehaviorSubject(defaultAccountInfo)),
       refCountDelay(1000),


### PR DESCRIPTION
Fixes exception:
> Uncaught TypeError: You provided an invalid object where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.
    at subscribeTo (subscribeTo.js?1716:28)
    at subscribeToResult (subscribeToResult.js?ce8b:15)
    at SwitchMapSubscriber._innerSub (switchMap.js?d792:51)
    at SwitchMapSubscriber._next (switchMap.js?d792:41)
    at SwitchMapSubscriber.Subscriber.next (Subscriber.js?1453:53)
    at SwitchMapSubscriber.notifyNext (switchMap.js?d792:72)
    at InnerSubscriber._next (InnerSubscriber.js?acf8:15)
    at InnerSubscriber.Subscriber.next (Subscriber.js?1453:53)
    at MapSubscriber._next (map.js?ebb6:41)
    at MapSubscriber.Subscriber.next (Subscriber.js?1453:53)
    at AsyncAction.dispatch (timer.js?808d:31)
    at AsyncAction._execute (AsyncAction.js?87d0:64)
    at AsyncAction.execute (AsyncAction.js?87d0:52)
    at AsyncScheduler.flush (AsyncScheduler.js?092f:43)

introduced in #910

Steps to reproduce:
- Create a new account
- Refresh page