### PR TITLE
cordova android: Allow to open arbitrary sites

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -11,14 +11,8 @@
     <allow-intent href="sms:*" />
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
+    <access origin="*" />
     <platform name="android">
-        <access origin="*.aepps.com" />
-        <access origin="*.piwo.app" />
-        <access origin="aeternity.com" />
-        <access origin="*.aeternity.com" />
-        <access origin="api.backendless.com" />
-        <access origin="api.coingecko.com" />
-        <access origin="cors-anywhere.herokuapp.com" />
         <allow-intent href="market:*" />
         <preference name="SplashMaintainAspectRatio" value="true" />
         <preference name="HeaderColor" value="#f7296e" />
@@ -27,7 +21,6 @@
         </edit-config>
     </platform>
     <platform name="ios">
-        <access origin="*" />
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <allow-navigation href="*" />

--- a/src/pages/mobile/Apps.vue
+++ b/src/pages/mobile/Apps.vue
@@ -3,6 +3,10 @@
     class="apps"
     fill="neutral"
   >
+    <Guide :template="$t('app.list.browse-guide')" />
+
+    <UrlForm @input="searchTerm = $event" />
+
     <Guide :template="$t('app.list.featured-guide')" />
 
     <AeCard fill="maximum">
@@ -27,10 +31,6 @@
         </p>
       </template>
     </AeCard>
-
-    <Guide :template="$t('app.list.browse-guide')" />
-
-    <UrlForm @input="searchTerm = $event" />
 
     <template v-if="bookmarkedApps.length">
       <Guide :template="$t('app.list.bookmarked-guide')" />

--- a/tests/examples/cordova-android-bridge-access/index.html
+++ b/tests/examples/cordova-android-bridge-access/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Cordova android bridge access test</title>
+
+  <style>
+    #actions, #actions > button {
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <div id="actions">
+    <button id="init">init</button>
+    <button id="execCopy">exec copy</button>
+  </div>
+  <pre id="output"></pre>
+  <script>
+    document.body.prepend(`Cordova android bridge interface ${window._cordovaNative ? '' : 'not '}available`);
+    let bridgeSecret;
+
+    if (window._cordovaNative) {
+      window.init.addEventListener('click', () => {
+        bridgeSecret = +prompt('', 'gap_init:' + 3);
+        window.output.innerText = `bridgeSecret: ${bridgeSecret}`;
+      });
+
+      window.execCopy.addEventListener('click', () => {
+        window.output.innerText = window._cordovaNative
+          .exec(bridgeSecret, 'Clipboard', 'copy', 8, '["test"]');
+      });
+    } else {
+      window.actions.style.display = 'none';
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
closes #718 

To be able to call bridge's exec method caller should know the secret that can be retrieved by calling prompt with `gap_init:<mode>` default value. To get secret is not possible for aepp because:
- prompts and alerts are disallowed by the lack of `allow-modals` in iframe sandbox attribute: https://github.com/aeternity/aepp-base/blob/9157e56ce727e6879f1f8678f75a843bccbc401b/src/pages/mobile/AppBrowser.vue#L41
- calling of `gap_init:<mode>` is allowed only for domains that allowed navigation to in config.xml, we allowing this navigation only for `file://` URLs right now
https://github.com/apache/cordova-android/blob/bd1697dbd27411d8b12d9ad0902babaaae327efa/framework/src/org/apache/cordova/CordovaBridge.java#L173-L182
https://github.com/apache/cordova-android/blob/bd1697dbd27411d8b12d9ad0902babaaae327efa/framework/src/org/apache/cordova/PluginManager.java#L400-L413
https://github.com/apache/cordova-android/blob/bd1697dbd27411d8b12d9ad0902babaaae327efa/framework/src/org/apache/cordova/CordovaPlugin.java#L264-L266