### PR TITLE
veeValidate: Convert amountAe to number

### DIFF
--- a/src/store/plugins/ui/veeValidate.js
+++ b/src/store/plugins/ui/veeValidate.js
@@ -79,7 +79,7 @@ export default (store) => {
   Validator.localize('en', {
     messages: {
       max_value_currency: (field, [amountAe]) => {
-        let amount = amountAe;
+        let amount = +amountAe;
         if (store.state.currencies.swapped) {
           store.state.observables.rate
             .subscribe((rate) => { amount = amountAe * rate; })


### PR DESCRIPTION
Fixes this problem:
![image](https://user-images.githubusercontent.com/7098449/63828785-f0051900-c9aa-11e9-9bb3-c92922ff7a9e.png)
When currencies is not swapped, typeof amount is String, cause it's passed as string to validator