### PR TITLE
More safe usage of DOMRect

### DIFF
--- a/src/components/AePopover.vue
+++ b/src/components/AePopover.vue
@@ -13,6 +13,7 @@
 import Vue from 'vue';
 import { isEqual } from 'lodash-es';
 import { directive as clickaway } from 'vue-clickaway';
+import { DOMRect } from '../lib/utils';
 
 const originProp = {
   type: Object,
@@ -59,11 +60,14 @@ export default {
         ? new DOMRect(-window.scrollX, -window.scrollY) : parentEl.getBoundingClientRect();
 
       const anchorElRect = anchorEl.getBoundingClientRect();
-      anchorElRect.x -= parentElRect.x;
-      anchorElRect.y -= parentElRect.y;
       const {
         top, right, bottom, left,
-      } = anchorElRect;
+      } = new DOMRect(
+        anchorElRect.left - parentElRect.left,
+        anchorElRect.top - parentElRect.top,
+        anchorElRect.width,
+        anchorElRect.height,
+      );
 
       const anchorPoint = {
         x: {

--- a/src/components/mobile/Tooltip.vue
+++ b/src/components/mobile/Tooltip.vue
@@ -25,13 +25,14 @@
 import { clamp } from 'lodash-es';
 import ButtonPlain from '../ButtonPlain.vue';
 import { Close } from '../icons';
+import { DOMRect } from '../../lib/utils';
 
 const arrowSize = 12;
 
 export default {
   components: { ButtonPlain, Close },
   props: {
-    anchorRect: { type: DOMRect, default: null },
+    anchorRect: { type: [DOMRect, window.DOMRect], default: null },
   },
   data: () => ({ isMounted: false }),
   computed: {

--- a/src/components/mobile/TooltipsModal.vue
+++ b/src/components/mobile/TooltipsModal.vue
@@ -69,7 +69,7 @@ export default {
           rect.height + padding * 2,
         ));
     };
-    updateAnchorRects();
+    setTimeout(updateAnchorRects);
     window.addEventListener('resize', updateAnchorRects);
     window.addEventListener('scroll', updateAnchorRects);
     this.$once('hook:destroyed', () => {

--- a/src/components/mobile/TooltipsModal.vue
+++ b/src/components/mobile/TooltipsModal.vue
@@ -32,6 +32,7 @@
 </template>
 
 <script>
+import { DOMRect } from '../../lib/utils';
 import Tooltip from './Tooltip.vue';
 
 export default {
@@ -62,8 +63,8 @@ export default {
       this.anchorRects = this.tooltips
         .map(({ selector }) => document.querySelector(selector).getBoundingClientRect())
         .map(rect => new DOMRect(
-          rect.x - padding,
-          rect.y - padding,
+          rect.left - padding,
+          rect.top - padding,
           rect.width + padding * 2,
           rect.height + padding * 2,
         ));

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -18,3 +18,17 @@ export class ConvertibleToString {
     this.toString = toString;
   }
 }
+
+export class DOMRect {
+  constructor(left, top, width, height) {
+    this.left = left;
+    this.top = top;
+    this.width = width;
+    this.height = height;
+    Object.freeze(this);
+  }
+
+  get right() { return this.left + this.width; }
+
+  get bottom() { return this.top + this.height; }
+}


### PR DESCRIPTION
probably fixes #1197 

I have hound an Asus Z00RD with "Resurrection Remix OS" firmware, Android 7.1.2 and it has LineageOS Browser preinstalled what uses stock AOSP WebView (`Mozilla/5.0 (Linux; Android 7.1.2; ASUS_Z00RD Build/NJH47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.92 Mobile Safari/537.36`).

In that WebView, the Base app showing the white screen with a warning `Unhandled rejection ReferenceError: DOMRect is not defined` in both Cordova and LineageOS Browser.

So, in this PR
- avoided explicit usage of DOMRect type
- rewritten usage of rects in a way compatible with that WebView