### PR TITLE
ui: Call global error handler if exception raised in async code

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -29,4 +29,6 @@ if (!process.env.IS_MASTER) {
   }).$mount('#app');
 
   uiPlugin(store);
-})();
+})().catch((error) => {
+  window.onerror(error.message, error.fileName, error.lineNumber, undefined, error);
+});


### PR DESCRIPTION
After this Base app will show "Store load error" screen instead of the white empty screen in cases like #1214
https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error