### PR TITLE
appsMetadata: Rely on built-in caching functionality

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -29,7 +29,6 @@ export default new Vuex.Store({
         migrations, sdkUrl, customNetworks,
         apps, peerId, languages, currencies, names: { defaults } = {},
         accounts: { list, activeIdx, hdWallet: { encryptedWallet, mnemonicBackedUp } = {} } = {},
-        appsMetadata: { cachedManifests } = {},
         mobile: { readSecurityCourses, followers, skipAddingToHomeScreen } = {},
         desktop: { showGuideOnStartup } = {},
       }) => ({
@@ -55,7 +54,6 @@ export default new Vuex.Store({
           activeIdx,
           hdWallet: { encryptedWallet, mnemonicBackedUp },
         },
-        appsMetadata: { cachedManifests },
         apps,
         ...process.env.IS_MOBILE_DEVICE ? {
           mobile: {

--- a/src/store/plugins/ui/__tests__/appsMetadata.js
+++ b/src/store/plugins/ui/__tests__/appsMetadata.js
@@ -28,7 +28,7 @@ describe('appsMetadata', () => {
     `returns app metadata for ${name}`,
     async () => {
       const host = 'example.com';
-      store.commit('appsMetadata/setCachedManifest', { host, manifest });
+      store.commit('appsMetadata/setManifest', { host, manifest });
       expect(store.getters['appsMetadata/get'](host)).toEqual({
         ...manifest,
         ...metadata,


### PR DESCRIPTION
Explicit caching of manifests is not necessary, because the same is already done on the http layer. The caching interval can be adjusted by aepp developers using corresponding http-headers, it is more flexible than the hard-coded 24h solution.

closes #1291