### PR TITLE
Add catching deeplinks

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -34,6 +34,16 @@
         <edit-config file="*-Info.plist" mode="merge" target="UIUserInterfaceStyle">
             <string>Light</string>
         </edit-config>
+        <config-file target="*-Debug.plist" parent="com.apple.developer.associated-domains">
+            <array>
+                <string>applinks:base.aepps.com</string>
+            </array>
+        </config-file>
+        <config-file target="*-Release.plist" parent="com.apple.developer.associated-domains">
+            <array>
+                <string>applinks:base.aepps.com</string>
+            </array>
+        </config-file>
     </platform>
     <preference name="SplashScreen" value="screen" />
     <preference name="ShowSplashScreenSpinner" value="false" />
@@ -44,9 +54,6 @@
     <plugin name="cordova-plugin-whitelist" spec="^1.3.3" />
     <plugin name="cordova-plugin-splashscreen" spec="^5.0.2" />
     <plugin name="cordova-plugin-network-information" spec="^2.0.1" />
-    <plugin name="cordova-plugin-customurlscheme" spec="^4.4.0">
-        <variable name="URL_SCHEME" value="aepp-base" />
-    </plugin>
     <plugin name="cordova-plugin-qrscanner" spec="^3.0.1" />
     <plugin name="cordova-plugin-inappbrowser" spec="^3.0.0" />
     <plugin name="cordova-plugin-wkwebview-engine" spec="github:mwchambers/cordova-plugin-wkwebview-engine#da67d6bb6ce8597c38fc69e66b84566e34efea8d" />
@@ -55,6 +62,10 @@
     <plugin name="cordova-plugin-statusbar" spec="^2.4.2" />
     <plugin name="cordova-plugin-headercolor" spec="^1.0.0" />
     <plugin name="cordova-clipboard" spec="^1.3.0" />
+    <plugin name="ionic-plugin-deeplinks" spec="^1.0.20">
+        <variable name="URL_SCHEME" value="aepp-base" />
+        <variable name="DEEPLINK_HOST" value="base.aepps.com" />
+    </plugin>
     <engine name="android" spec="^8.0.0" />
     <engine name="ios" spec="^5.0.0" />
 </widget>

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.aeternity.base",
+      "sha256_cert_fingerprints": [
+        "9C:3D:17:92:24:A9:33:12:0E:0C:EE:34:D2:D5:19:54:81:BD:F6:3F:2F:79:6F:9F:CE:24:38:DE:F6:B4:5B:C4"
+      ]
+    }
+  }
+]

--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -1,0 +1,14 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "8H7FGC266S.com.aeternity.base",
+        "paths": [
+          "*",
+          "/"
+        ]
+      }
+    ]
+  }
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -12,7 +12,7 @@ export const isNotFoundError = error => error.isAxiosError
   && get(error, 'response.status') === 404;
 
 export const isInternalServerError = error => error.isAxiosError
-  && get(error, 'response.status') === 500;
+  && [500, 503].includes(get(error, 'response.status'));
 
 export const isAccountNotFoundError = error => isNotFoundError(error)
   && get(error, 'response.data.reason') === 'Account not found';

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -34,6 +34,12 @@ export default (async () => {
     && !store.state.mobile.skipAddingToHomeScreen
   ) await router.replace({ name: 'add-to-home-screen' });
 
+  if (process.env.IS_CORDOVA) {
+    window.IonicDeeplink.onDeepLink(
+      d => router.push((u => u.pathname + u.search)(new URL(d.url))),
+    );
+  }
+
   store.watch(
     (state, { loggedIn }) => loggedIn,
     (loggedIn) => {

--- a/src/store/plugins/ui/observables.js
+++ b/src/store/plugins/ui/observables.js
@@ -88,7 +88,10 @@ export default (store) => {
     );
   const topBlockHeight$ = createSdkObservable(async sdk => (await sdk.topBlock()).height, 0);
   const middlewareStatus$ = createSdkObservable(
-    sdk => sdk.middleware.getMdwStatus(),
+    sdk => sdk.middleware.getMdwStatus().catch((error) => {
+      handleUnknownError(error);
+      return { OK: false, queueLength: NaN };
+    }),
     { OK: true, queueLength: 0 },
   );
 


### PR DESCRIPTION
Closes #1135.
Part of #1353.
For example, it opens ConfirmTransactionSignModal in native on [http://base.aepps.com/transfer/send/ak_mxCZ2rVRSjh6mXrey2vDujAvQiCkd51b5XdrrgrXWX4mQkzug/0.1](url)
QR Code for the link:
![qr-code (1)](https://user-images.githubusercontent.com/7098449/71247861-57354780-2365-11ea-9867-6f25357b0a66.png)
