### PR TITLE
Wait for native code initialization before using deeplink interface

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -34,9 +34,8 @@ export default (async () => {
   ) await router.replace({ name: 'add-to-home-screen' });
 
   if (process.env.IS_CORDOVA) {
-    window.IonicDeeplink.onDeepLink(
-      d => router.push((u => u.pathname + u.search)(new URL(d.url))),
-    );
+    document.addEventListener('deviceready', () => window.IonicDeeplink
+      .onDeepLink(d => router.push((u => u.pathname + u.search)(new URL(d.url)))));
   }
 
   store.watch(


### PR DESCRIPTION
https://cordova.apache.org/docs/en/5.1.1/cordova/events/events.deviceready.html

It was causing this error before:
```
Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'window.IonicDeeplink.onDeepLink')
```