### PR TITLE
Add sign modals to reverse iframe

### DIFF
--- a/src/components/mobile/ConfirmSignModal.vue
+++ b/src/components/mobile/ConfirmSignModal.vue
@@ -1,5 +1,6 @@
 <template>
   <Page
+    :modal="!$globals.IS_MOBILE_DEVICE"
     fill="primary"
     hide-tab-bar
     right-button-icon-name="close"

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,16 +1,21 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import BigNumber from 'bignumber.js';
 import './ui-common';
 import store from './store';
 import languages, { i18n } from './store/plugins/ui/languages';
 import initSdk from './store/plugins/initSdk';
 import names from './store/plugins/ui/names';
 import appsMetadata from './store/plugins/ui/appsMetadata';
+import observables from './store/plugins/ui/observables';
+import currencies from './store/plugins/ui/currencies';
 import ConfirmAccountAccess from './components/ConfirmAccountAccess.vue';
+import ConfirmTransactionSignModal from './components/mobile/ConfirmTransactionSignModal.vue';
+import ConfirmSignModal from './components/mobile/ConfirmSignModal.vue';
 
 Vue.use(Vuex);
 
-[languages, initSdk, names, appsMetadata].forEach(plugin => plugin(store));
+[languages, initSdk, names, appsMetadata, observables, currencies].forEach(plugin => plugin(store));
 
 const unloadHandler = () => {
   window.reject(new Error('Rejected by user'));
@@ -28,11 +33,21 @@ new Vue({
   store,
   i18n,
   render: h => h(
-    ConfirmAccountAccess, {
+    {
+      confirmAccountAccess: ConfirmAccountAccess,
+      confirmTransactionSign: ConfirmTransactionSignModal,
+      confirmSign: ConfirmSignModal,
+    }[window.modalName], {
       props: {
-        ...window.props,
-        resolve: closingWrapper(window.props.resolve),
-        reject: closingWrapper(window.props.reject),
+        ...window.modalProps,
+        transaction: window.modalProps.transaction && {
+          ...window.modalProps.transaction,
+          amount: BigNumber(window.modalProps.transaction.amount),
+          fee: BigNumber(window.modalProps.transaction.fee),
+          minFee: BigNumber(window.modalProps.transaction.minFee),
+        },
+        resolve: closingWrapper(window.modalProps.resolve),
+        reject: closingWrapper(window.modalProps.reject),
       },
     },
   ),

--- a/src/store/modules/accounts/hdWallet.js
+++ b/src/store/modules/accounts/hdWallet.js
@@ -234,9 +234,7 @@ export default {
     },
 
     async confirmRawDataSigning({ dispatch }, data) {
-      if (type === 'hd-wallet') {
-        await dispatch('modals/open', { name: 'confirmSign', data }, { root: true });
-      }
+      await dispatch('modals/open', { name: 'confirmSign', data }, { root: true });
       return data;
     },
 

--- a/src/store/plugins/reverseIframe.js
+++ b/src/store/plugins/reverseIframe.js
@@ -3,6 +3,8 @@ import { BrowserWindowMessageConnection } from '@aeternity/aepp-sdk/es/utils/aep
 
 const modals = {
   confirmAccountAccess: true,
+  confirmTransactionSign: true,
+  confirmSign: true,
 };
 
 export default (store) => {
@@ -24,10 +26,11 @@ export default (store) => {
     actions: {
       open(_, { name, ...props }) {
         if (!modals[name]) return Promise.reject(new Error(`Modal with name "${name}" not registered`));
-        const popupWindow = window.open('/', 'popup', 'width=330,height=480');
+        const popupWindow = window.open('/', 'popup', 'width=530,height=730');
         if (!popupWindow) return Promise.reject(new Error('Can\'t show popup window'));
+        popupWindow.modalName = name;
         return new Promise((resolve, reject) => {
-          popupWindow.props = { ...props, resolve, reject };
+          popupWindow.modalProps = { ...props, resolve, reject };
         });
       },
     },


### PR DESCRIPTION
It should enable signing in reverse iframe when desktop version is working without mobile.