### PR TITLE
Make Cordova to don't use UIWebView on iOS

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -44,6 +44,11 @@
                 <string>applinks:base.aepps.com</string>
             </array>
         </config-file>
+        <preference name="WKWebViewOnly" value="true" />
+        <feature name="CDVWKWebViewEngine">
+            <param name="ios-package" value="CDVWKWebViewEngine" />
+        </feature>
+        <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
     </platform>
     <preference name="SplashScreen" value="screen" />
     <preference name="ShowSplashScreenSpinner" value="false" />


### PR DESCRIPTION
As made by https://github.com/aeternity/superhero-wallet/pull/88
Made according to https://cordova.apache.org/howto/2020/03/18/wkwebviewonly.html

Supposed to fix this warning:

> ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of new apps that use UIWebView APIs starting from April 2020. See https://developer.apple.com/documentation/uikit/uiwebview for more information.