### PR TITLE
fix: don't provide internal url that is not used and working

### DIFF
--- a/src/store/plugins/initSdk.js
+++ b/src/store/plugins/initSdk.js
@@ -85,10 +85,7 @@ export default (store) => {
       Ae.compose(ChainNode, Transaction, Contract, Aens, WalletRPC, { methods })({
         nodes: [{
           name: network.name,
-          instance: await Node({
-            url: network.url,
-            internalUrl: network.url,
-          }),
+          instance: await Node({ url: network.url }),
         }],
         compilerUrl: network.compilerUrl,
         name: 'Base Aepp',


### PR DESCRIPTION
There is an extra error message otherwise:
<img width="630" alt="Screenshot 2023-05-17 at 16 14 08" src="https://github.com/aeternity/aepp-base/assets/9007851/973feed8-228b-498f-8c94-234679696296">

This PR is supported by the Æternity Crypto Foundation