### PR TITLE
Override network, backend url through env variables after build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,4 @@
 !.postcssrc.js
 !babel.config.js
 !vue.config.js
-!docker/nginx.conf
+!docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN npm ci --legacy-peer-deps
 
 COPY . .
 
-ARG VUE_APP_BACKEND_URL
-
 # TODO: remove legacy openssl after updating @vue/cli
 RUN NODE_OPTIONS=--openssl-legacy-provider npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,6 @@ RUN npm ci --legacy-peer-deps
 
 COPY . .
 
-ARG VUE_APP_NETWORK_NAME
-ARG VUE_APP_NODE_URL
-ARG VUE_APP_MDW_URL
-ARG VUE_APP_EXPLORER_URL
-ARG VUE_APP_COMPILER_URL
 ARG VUE_APP_BACKEND_URL
 
 # TODO: remove legacy openssl after updating @vue/cli
@@ -20,4 +15,6 @@ RUN NODE_OPTIONS=--openssl-legacy-provider npm run build
 
 FROM nginx:1.24-alpine
 COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/override-env.sh /docker-entrypoint.d
 COPY --from=aepp-aepp-base-build /app/dist /usr/share/nginx/html
+RUN cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.template.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: aepp-base
     build:
       context: .
-      args:
-        VUE_APP_BACKEND_URL: http://localhost:3079
     ports: ["3080:80"]
+    environment:
+      - VUE_APP_BACKEND_URL=http://localhost:3079
   backend:
     image: aepp-base-backend
     build: backend

--- a/docker/override-env.sh
+++ b/docker/override-env.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+envsubst < /usr/share/nginx/html/index.template.html > /usr/share/nginx/html/index.html

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
         explorerUrl: '$VUE_APP_EXPLORER_URL',
         compilerUrl: '$VUE_APP_COMPILER_URL',
       };
+      window.overrideBackendUrl = '$VUE_APP_BACKEND_URL';
     </script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,16 @@
     <meta name="description" content="The æternity blockchain wallet allows users to store, send, and receive æternity coins. The wallet also features an æpps (applications running on the æternity blockchain) browser.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
+    <script>
+      window.overrideNetwork = {
+        name: '$VUE_APP_NETWORK_NAME',
+        url: '$VUE_APP_NODE_URL',
+        middlewareUrl: '$VUE_APP_MIDDLEWARE_URL',
+        explorerUrl: '$VUE_APP_EXPLORER_URL',
+        compilerUrl: '$VUE_APP_COMPILER_URL',
+      };
+    </script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <% googleFontsUrl = 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&display=swap' %>

--- a/src/lib/networksRegistry.js
+++ b/src/lib/networksRegistry.js
@@ -14,24 +14,21 @@ const testNetwork = {
   compilerUrl: 'https://compiler.aepps.com',
 };
 
-let networks = process.env.NODE_ENV === 'production' ? [
-  mainNetwork,
-  testNetwork,
-] : [
-  testNetwork,
-  mainNetwork,
-];
-
-export const defaultNetwork = process.env.VUE_APP_NETWORK_NAME ? {
+const envNetwork = {
   name: process.env.VUE_APP_NETWORK_NAME,
   url: process.env.VUE_APP_NODE_URL,
-  middlewareUrl: process.env.VUE_APP_MDW_URL,
+  middlewareUrl: process.env.VUE_APP_MIDDLEWARE_URL,
   explorerUrl: process.env.VUE_APP_EXPLORER_URL,
   compilerUrl: process.env.VUE_APP_COMPILER_URL,
-} : mainNetwork;
+};
 
-if (process.env.VUE_APP_NETWORK_NAME) {
-  networks = [defaultNetwork];
-}
+const networks = (() => {
+  if (!['', '$VUE_APP_NETWORK_NAME'].includes(window.overrideNetwork.name)) {
+    return [window.overrideNetwork];
+  }
+  if (envNetwork.name) return [envNetwork];
+  if (process.env.NODE_ENV === 'production') return [mainNetwork, testNetwork];
+  return [testNetwork, mainNetwork];
+})();
 
 export default Object.freeze(networks.map(Object.freeze));

--- a/src/store/modules/root.js
+++ b/src/store/modules/root.js
@@ -2,7 +2,7 @@
 
 import Vue from 'vue';
 import { update, mergeWith } from 'lodash-es';
-import networksRegistry, { defaultNetwork } from '../../lib/networksRegistry';
+import networksRegistry from '../../lib/networksRegistry';
 import { genRandomBuffer } from '../utils';
 
 const getAppByHost = (apps, appHost) => apps.find(({ host }) => host === appHost);
@@ -23,10 +23,10 @@ export default {
   getters: {
     networks: ({ customNetworks }) => [
       ...networksRegistry,
-      ...customNetworks.map((network) => ({ ...defaultNetwork, ...network, custom: true })),
+      ...customNetworks.map((network) => ({ ...networksRegistry[0], ...network, custom: true })),
     ],
     currentNetwork: ({ sdkUrl }, { networks }) => networks.find(({ url }) => url === sdkUrl) || {
-      ...defaultNetwork,
+      ...networksRegistry[0],
       name: sdkUrl,
       url: sdkUrl,
     },

--- a/src/store/plugins/remoteConnection.js
+++ b/src/store/plugins/remoteConnection.js
@@ -54,7 +54,9 @@ export default (store) => {
     if (ENV_MOBILE_DEVICE) {
       auth.pushApiSubscription = await getPushApiSubscription();
     }
-    const socket = (await io())(process.env.VUE_APP_BACKEND_URL, { auth });
+    const backendUrl = ['', '$VUE_APP_BACKEND_URL'].includes(window.overrideBackendUrl)
+      ? process.env.VUE_APP_BACKEND_URL : window.overrideBackendUrl;
+    const socket = (await io())(backendUrl, { auth });
     const closeCbs = [socket.close.bind(socket)];
 
     let processedState = cloneDeep(getStateForSync(store.state));


### PR DESCRIPTION
closes #1469 ~(VUE_APP_REMOTE_CONNECTION_BACKEND_URL would be handled separately)~

I've did some research and found several approaches.

### Store configuration in a separate files (would produce an extra request)
https://www.npmjs.com/package/react-inject-env
https://www.codecentric.de/wissens-hub/blog/react-application-container-environment-aware-kubernetes-deployment

### Specify env value in index.html
https://github.com/axelhzf/create-react-app-docker-environment-variables
https://iendeavor.github.io/import-meta-env/ (a complete tools set, looks overcomplicated)

### Build on each container run
https://github.com/mikesparr/tutorial-react-docker

### Discussions
https://stackoverflow.com/questions/52103155/reading-an-environment-variable-in-react-which-was-set-by-docker
https://stackoverflow.com/questions/49975735/rendering-an-environment-variable-to-the-browser-in-a-react-js-redux-production
https://github.com/facebook/create-react-app/issues/982#issuecomment-312577293

This way I can override network without rebuilding container, tested with
```yaml
version: '3'
services:
  frontend:
    image: aepp-base
    build:
      context: .
    ports: ["3080:80"]
    environment:
      - VUE_APP_NETWORK_NAME=balabola network!
      - VUE_APP_NODE_URL=https://example.com
      - VUE_APP_MIDDLEWARE_URL=https://example.com
      - VUE_APP_EXPLORER_URL=https://example.com
      - VUE_APP_COMPILER_URL=https://example.com
      - VUE_APP_BACKEND_URL=https://example.com
```
```bash
export VUE_APP_NETWORK_NAME="balabola network!"
export VUE_APP_NODE_URL=https://example.com
export VUE_APP_MIDDLEWARE_URL=https://example.com
export VUE_APP_EXPLORER_URL=https://example.com
export VUE_APP_COMPILER_URL=https://example.com
export VUE_APP_BACKEND_URL=https://example.com
npm run build
```

This PR is supported by the Æternity Crypto Foundation