### PR TITLE
fix: don't fetch metadata over http if loaded via https

### DIFF
--- a/src/store/plugins/ui/appsMetadata.js
+++ b/src/store/plugins/ui/appsMetadata.js
@@ -49,7 +49,7 @@ export default (store) => store.registerModule('appsMetadata', {
   actions: {
     async fetchManifest(_, host) {
       const fetchText = async (url) => (await fetch(url)).text();
-      let appUrl = new URL(`http://${host}`);
+      let appUrl = new URL(`https://${host}`);
       if (appUrl.hostname === 'localhost') return {};
 
       const parser = new DOMParser();


### PR DESCRIPTION
To avoid error:
Mixed Content: The page at 'https://docs.aeternity.com/aepp-base-home-page/' was loaded over HTTPS, but requested an insecure resource 'http://migrate.aeternity.com/'. This request has been blocked; the content must be served over HTTPS.

This PR is supported by the Æternity Crypto Foundation